### PR TITLE
Delete saved creds on auth failure and rename creds var

### DIFF
--- a/protocols/sibyl_matrix.py
+++ b/protocols/sibyl_matrix.py
@@ -141,7 +141,7 @@ class MatrixProtocol(Protocol):
   #   self.log = the logger you should use
   def setup(self):
     self.rooms = {}
-    self.bot.add_var("credentials",persist=True)
+    self.bot.add_var("matrix_creds",persist=True)
 
     # Incoming message queue - messageHandler puts messages in here and
     # process() looks here periodically to send them to sibyl
@@ -165,12 +165,12 @@ class MatrixProtocol(Protocol):
       self.log.debug("Logging in as %s" % user)
 
       # Log in with the existing access token if we already have a token
-      if(self.bot.credentials and self.bot.credentials[0] == user):
-        self.client = MatrixClient(homeserver, user_id=user, token=self.bot.credentials[1])
+      if(self.bot.matrix_creds and self.bot.matrix_creds[0] == user):
+        self.client = MatrixClient(homeserver, user_id=user, token=self.bot.matrix_creds[1])
       # Otherwise, log in with the configured username and password
       else:
         token = self.client.login_with_password(user,pw)
-        self.bot.credentials = (user, token)
+        self.bot.matrix_creds = (user, token)
 
       self.rooms = self.client.get_rooms()
       self.log.debug("Already in rooms: %s" % self.rooms)
@@ -185,6 +185,7 @@ class MatrixProtocol(Protocol):
     except MatrixRequestError as e:
       if(e.code in [401, 403]):
         self.log.debug("Credentials incorrect! Maybe your access token is outdated?")
+        self.bot.matrix_creds = None
         raise self.AuthFailure
       else:
         if(self.opt('matrix.debug')):


### PR DESCRIPTION
In the event an access token is revoked, we might still have user/pass
credentials that are valid. If we receive a 401 or 403, we can be
reasonably sure that the credentials in the bot's state are invalid,
so let's just clear them out.

Sibyl will still disable the Matrix protocol if this happens,
requiring a restart; this just ensures that you won't have to dig
around in/delete the pickled state to get back up and running.