### PR TITLE
close #72

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -62,10 +62,9 @@ def xbmc(ip,method,params=None,user=None,pword=None,timeout=5):
 
   url = 'http://'+ip+'/jsonrpc'
   headers = {'content-type':'application/json'}
-  payload = p
-  params = {'request':json.dumps(payload)}
+  data = json.dumps(p)
   auth = (user,pword)
-  r = requests.get(url,params=params,headers=headers,auth=auth,timeout=timeout)
+  r = requests.post(url,data=data,headers=headers,auth=auth,timeout=timeout)
 
   # return the response from xbmc as a dict
   return json.loads(r.text)


### PR DESCRIPTION
Use HTTP POST instead of GET because kodi 18 restricts GET
requests to access-only. In order to change anything it now
requires POST requests.

 - https://forum.kodi.tv/showthread.php?tid=324598
 - https://github.com/xbmc/xbmc/pull/12281
 - https://kodi.wiki/view/JSON-RPC_API#POST
 - https://github.com/TheSchwa/sibyl/blob/8dd893e7b0f671f681703548aed709160bd47dc3/lib/util.py#L68