### PR TITLE
client3.py fix password as cli arg

### DIFF
--- a/client3.py
+++ b/client3.py
@@ -224,8 +224,11 @@ class CLI(object):
 
   def get_pass(self):
 
-    if self.args.password is None:
-      return None
+    # "-p PASSWORD" OR -p not passed
+    if self.args.password is not '':
+      return self.args.password
+
+    # "-p" without a value means get user input
     print('')
     pword = getpass.getpass()
     print('')


### PR DESCRIPTION
Need to handle 3 cases:
1. `-p` isn't used, `args.password = None`
2. `-p` is used without a value, `args.password = ''`
3. `-p PASSWORD` is used, `args.password = 'PASSWORD'`

Current code does not allow for 3; the value is ignored and a prompt is still generated.